### PR TITLE
Better handling of edge-cases

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -681,7 +681,7 @@ def lambda_handler(event, context):
         )
         if len(unprocessed_execution_arns):
             logger.info(
-                "%s executions needs to be processed at a later time due to failed states that have not yet been recovered '%s'",
+                "%s executions need to be processed at a later time due to failed executions/states that have not yet been recovered '%s'",
                 len(unprocessed_execution_arns),
                 json.dumps(unprocessed_execution_arns),
             )

--- a/src/main.py
+++ b/src/main.py
@@ -599,7 +599,7 @@ def lambda_handler(event, context):
                 None,
             ):
                 logger.info(
-                    "Skipping metric collection and reporting for state machine %s as we need to wait for one or more running executions to finish before we can accurately calculate metrics",
+                    "Skipping metric collection and reporting for state machine '%s' as we need to wait for one or more running executions to finish before metrics can be accurately calculated",
                     state_machine_name,
                 )
                 continue

--- a/src/main.py
+++ b/src/main.py
@@ -348,6 +348,8 @@ def get_metrics(state_machine_name, executions):
                     failed_states.get(state_name, None)
                     and failed_states[state_name]["startDate"].timestamp()
                     < e["startDate"].timestamp()
+                    and failed_states[state_name]["fail_event"]["timestamp"]
+                    < state["success_event"]["timestamp"]
                 ):
                     metrics.append(
                         {

--- a/src/main.py
+++ b/src/main.py
@@ -436,6 +436,7 @@ def get_metrics(state_machine_name, executions):
     for state_name, state_data in failed_states.items():
         if state_data:
             unprocessed_execution_arns.append(state_data["executionArn"])
+    unprocessed_execution_arns = list(set(unprocessed_execution_arns))
     return metrics, unprocessed_execution_arns
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -574,10 +574,13 @@ def lambda_handler(event, context):
         )["executions"]
         executions = sorted(executions, key=lambda e: e["startDate"])
         completed_executions = []
-        for e in executions:
-            if e["status"] == "RUNNING":
+        for i, execution in enumerate(executions):
+            if execution["status"] == "RUNNING" or (
+                i < (len(executions) - 1)
+                and executions[i + 1]["status"] == "RUNNING"
+            ):
                 break
-            completed_executions.append(e)
+            completed_executions.append(execution)
         new_executions = filter_processed_executions(
             completed_executions, s3_bucket, s3_prefix
         )

--- a/src/main.py
+++ b/src/main.py
@@ -346,8 +346,6 @@ def get_metrics(state_machine_name, executions):
                 # Check if recovered from failed state, in which case calculate MTTR
                 if (
                     failed_states.get(state_name, None)
-                    and failed_states[state_name]["startDate"].timestamp()
-                    < e["startDate"].timestamp()
                     and failed_states[state_name]["fail_event"]["timestamp"]
                     < state["success_event"]["timestamp"]
                 ):

--- a/src/main.py
+++ b/src/main.py
@@ -580,6 +580,7 @@ def lambda_handler(event, context):
         )["executions"]
         executions = sorted(executions, key=lambda e: e["startDate"])
         completed_executions = []
+        first_running_execution = None
         for i, execution in enumerate(executions):
             if execution["status"] == "RUNNING":
                 first_running_execution = execution
@@ -587,9 +588,12 @@ def lambda_handler(event, context):
             completed_executions.append(execution)
         completed_executions_filtered = list(
             filter(
-                lambda execution: execution["status"] == "SUCCEEDED"
-                and execution["stopDate"]
-                < first_running_execution["startDate"],
+                lambda execution: not first_running_execution
+                or (
+                    execution["status"] != "SUCCEEDED"
+                    and execution["stopDate"]
+                    < first_running_execution["startDate"]
+                ),
                 completed_executions,
             )
         )

--- a/src/main.py
+++ b/src/main.py
@@ -385,6 +385,17 @@ def get_metrics(state_machine_name, executions):
                             },
                         }
                     )
+                    logger.info(
+                        "State '%s' recovered by execution '%s' in %s seconds",
+                        state_name,
+                        e["name"],
+                        (
+                            state["success_event"]["timestamp"]
+                            - failed_states[state_name]["fail_event"][
+                                "timestamp"
+                            ]
+                        ).total_seconds(),
+                    )
                     failed_states[state_name] = None
             if state["fail_event"]:
                 if (

--- a/src/main.py
+++ b/src/main.py
@@ -577,7 +577,7 @@ def lambda_handler(event, context):
         state_machine_name = state_machine_arn.split(":")[6]
         s3_prefix = f"{current_account_id}/{state_machine_name}"
         executions = sfn.list_executions(
-            stateMachineArn=state_machine_arn, maxResults=100,
+            stateMachineArn=state_machine_arn, maxResults=500,
         )["executions"]
         executions = sorted(executions, key=lambda e: e["startDate"])
         completed_executions = []

--- a/src/main.py
+++ b/src/main.py
@@ -672,6 +672,11 @@ def lambda_handler(event, context):
         metrics, unprocessed_execution_arns = get_metrics(
             state_machine_name, detailed_new_executions
         )
+        logger.info(
+            "Calculated %s metrics for state machine '%s'",
+            len(metrics),
+            state_machine_name,
+        )
         if len(unprocessed_execution_arns):
             logger.info(
                 "%s executions needs to be processed at a later time due to failed states that have not yet been recovered '%s'",

--- a/src/main.py
+++ b/src/main.py
@@ -337,9 +337,10 @@ def get_metrics(state_machine_name, executions):
         elif execution["status"] != "SUCCEEDED":
             execution_failure_chain.append(execution)
 
-    unprocessed_execution_arns += list(
-        map(lambda e: e["executionArn"], execution_failure_chain)
-    )
+    if len(execution_failure_chain):
+        unprocessed_execution_arns.append(
+            execution_failure_chain[0]["executionArn"]
+        )
 
     # Get metrics on a state basis
     for state_name, events in states.items():
@@ -484,9 +485,10 @@ def get_metrics(state_machine_name, executions):
             else:
                 failure_chain.append(event)
 
-        unprocessed_execution_arns += list(
-            map(lambda e: e["execution"]["executionArn"], failure_chain)
-        )
+        if len(failure_chain):
+            unprocessed_execution_arns.append(
+                failure_chain[0]["execution"]["executionArn"]
+            )
 
     unprocessed_execution_arns = list(set(unprocessed_execution_arns))
     return metrics, unprocessed_execution_arns

--- a/src/main.py
+++ b/src/main.py
@@ -323,7 +323,7 @@ def get_metrics(state_machine_name, executions):
             execution_failure_chain = []
             logger.info(
                 "Failed execution '%s' recovered by execution '%s' in %s seconds",
-                failed_execution["execution"]["name"],
+                failed_execution["name"],
                 execution["name"],
                 (
                     execution["stopDate"] - failed_execution["stopDate"]

--- a/src/main.py
+++ b/src/main.py
@@ -588,9 +588,10 @@ def lambda_handler(event, context):
             completed_executions.append(execution)
         completed_executions_filtered = list(
             filter(
-                lambda execution: not first_running_execution
+                lambda execution: (execution["status"] != "SUCCEEDED")
+                or not first_running_execution
                 or (
-                    execution["status"] != "SUCCEEDED"
+                    first_running_execution
                     and execution["stopDate"]
                     < first_running_execution["startDate"]
                 ),


### PR DESCRIPTION
There are some challenges in getting an accurate metric for the `StateRecovery` metric (time it takes for a state to succeed after a failure), because it is not guaranteed that a list of sequential, completed executions contain the most accurate data for that metric (i.e., there may actually be a `RUNNING` execution that recovered the state at an earlier time than the completed execution).

This PR introduces some mechanisms to counter-act inaccurate metrics being calculated and reported, and more robust handling of edge-cases:
- If there exists a `RUNNING` execution that started before a `SUCCEEDED` execution was finished, we defer metric collection and reporting for that state machine until the next Lambda invocation (at which time the `RUNNING` execution hopefully is finished).
- Avoid saving executions to S3 (i.e., mark them as _unprocessed_) if we will need them later when calculating `StateMachine`-/`StateRecovery` (e.g., when we have failed executions/states that have not yet been recovered by another execution).
- Sort executions by `stopDate` when calculating `StateMachineRecovery`.
- Sort states by timestamp of success/fail event when calculating `StateRecovery`.