### PR TITLE
Add optional bucket replication

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -9,6 +9,17 @@ data "aws_iam_policy_document" "lambda_assume" {
   }
 }
 
+data "aws_iam_policy_document" "s3_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["s3.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
 # TODO: Scope this down?
 data "aws_iam_policy_document" "cloudwatch_for_lambda" {
   statement {
@@ -72,5 +83,25 @@ data "aws_iam_policy_document" "logs_for_lambda" {
     resources = [
       "arn:aws:logs:${local.current_region}:${local.current_account_id}:log-group:/aws/lambda/${aws_lambda_function.this.function_name}*",
     ]
+  }
+}
+
+data "aws_iam_policy_document" "replication_for_s3" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObjectVersion", "s3:GetObjectVersionAcl"]
+    resources = ["${aws_s3_bucket.this.arn}/${local.current_account_id}/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ReplicateObject", "s3:ReplicateDelete"]
+    resources = ["arn:aws:s3:::${var.replication_destination_bucket}/${local.current_account_id}/*"]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,4 +36,7 @@ variable "schedule_expression" {
   default     = "rate(1 hour)"
 }
 
-
+variable "replication_destination_bucket" {
+  description = "The name of an S3 destination bucket to replicate data to."
+  default     = ""
+}


### PR DESCRIPTION
Step Functions execution data is currently saved in an S3 bucket belonging to the current account. If there are many accounts collecting such data, it can be advantageous to store all of this data in a centralized bucket as well.

This PR adds a variable to optionally enable replication of Step Functions execution data to another bucket. Only files prefixed by the current account id is replicated -- this makes it easy to set up cross-account permissions and avoid accidental overwrites/deletions in the centralized destination bucket.