### PR TITLE
Realtime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # terraform-aws-pipeline-metrics
-A Terraform module for creating a Lambda that periodically calculates and reports granular metrics for one or multiple AWS Step Functions state machines.
+A Terraform module for creating two Lambda functions:
+- one that periodically calculates and reports granular metrics for one or multiple AWS Step Functions state machines
+- a second that reports a few (near-)realtime metrics (e.g., for constructing CloudWatch Alarms if a given state fails).
 
 ## Metrics
-The metrics are calculated using data from `boto3`'s `sfn` client, which among many other things, gives you access to the timestamped _events_ that occurred during a given execution (`TaskStateEntered`, `TaskSucceeded`, `TaskFailed`, etc.). This "raw" data received from the API is saved in S3 for future analysis, as data about a given execution is only available through the API for 90 days.
+The metrics are calculated using data from `boto3`'s `sfn` client, which among many other things, gives you access to the timestamped _events_ that occurred during a given execution (`TaskStateEntered`, `TaskSucceeded`, `TaskFailed`, etc.).
 
+### Periodic metrics
 Three metrics are calculated on an execution-basis, and these metrics are calculated using basic execution data (i.e., did the execution succeed? When did it start and end?):
 - **StateMachineSuccess**: time it took for an execution to succeed (milliseconds).
 - **StateMachineFail**: time it took for an execution to fail (milliseconds).
@@ -14,7 +17,14 @@ Three metrics are calculated for each state in an execution, and these metrics a
 - **StateFail**: time it took for the state to fail (milliseconds).
 - **StateRecovery**: time it took for the state to go from fail to success (milliseconds).
 
-Metrics are published to CloudWatch as Custom Metrics and a CloudWatch dashboard is set up to visualize them. The metrics are additionally saved in DynamoDB to avoid publishing duplicate metrics in a later Lambda invocation.
+The "raw" data received from the API is further saved in S3 for future analysis, as data about a given execution is only available through the API for 90 days.
+
+The metrics are published to CloudWatch as Custom Metrics and a CloudWatch dashboard is set up to visualize them. The metrics are additionally saved in DynamoDB to avoid publishing duplicate metrics in a later Lambda invocation.
+
+### Realtime metrics
+Under a separate namespace, two metrics are collected after each Step Functions state machine execution ends:
+- **StateSuccess**: time it took for the state to succeed (milliseconds).
+- **StateFail**: time it took for the state to fail (milliseconds).
 
 ## Caveats
 Currently been tested on a large state machine without any loops, and mainly `Task` states.

--- a/main.tf
+++ b/main.tf
@@ -2,16 +2,24 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  current_account_id  = data.aws_caller_identity.current.account_id
-  current_region      = data.aws_region.current.name
-  state_machine_names = sort([for arn in var.state_machine_arns : split(":", arn)[6]])
-  metric_namespace    = "${var.name_prefix}-pipeline-metrics"
+  current_account_id        = data.aws_caller_identity.current.account_id
+  current_region            = data.aws_region.current.name
+  state_machine_names       = sort([for arn in var.state_machine_arns : split(":", arn)[6]])
+  metric_namespace          = "${var.name_prefix}-pipeline-metrics"
+  metric_namespace_realtime = "${var.name_prefix}-pipeline-metrics/realtime"
 }
 
 data "archive_file" "this" {
-  type        = "zip"
-  source_file = "${path.module}/src/main.py"
-  output_path = "${path.module}/src/main.zip"
+  type = "zip"
+  source {
+    filename = "main.py"
+    content  = file("${path.module}/src/main.py")
+  }
+  source {
+    filename = "realtime.py"
+    content  = file("${path.module}/src/realtime.py")
+  }
+  output_path = "${path.module}/.terraform_artifacts/main.zip"
 }
 
 resource "aws_dynamodb_table" "this" {
@@ -64,6 +72,22 @@ resource "aws_lambda_function" "this" {
   tags    = var.tags
 }
 
+resource "aws_lambda_function" "realtime" {
+  function_name    = "${var.name_prefix}-pipeline-metrics-realtime"
+  handler          = "realtime.lambda_handler"
+  role             = aws_iam_role.this.arn
+  runtime          = "python3.7"
+  filename         = data.archive_file.this.output_path
+  source_code_hash = filebase64sha256(data.archive_file.this.output_path)
+  environment {
+    variables = {
+      METRIC_NAMESPACE = local.metric_namespace_realtime
+    }
+  }
+  timeout = var.lambda_timeout
+  tags    = var.tags
+}
+
 resource "aws_iam_role" "this" {
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
   tags               = var.tags
@@ -94,6 +118,12 @@ resource "aws_iam_role_policy" "step_functions_to_lambda" {
   role   = aws_iam_role.this.id
 }
 
+
+####################################################
+#
+# EventBridge
+#
+####################################################
 resource "aws_cloudwatch_event_rule" "this" {
   description         = "Invoke the metric Lambda on a schedule"
   schedule_expression = var.schedule_expression
@@ -110,6 +140,61 @@ resource "aws_lambda_permission" "this" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.this.arn
 }
+
+resource "aws_cloudwatch_event_rule" "sfn_end" {
+  description   = "Triggers when an AWS Step Functions state machine execution succeeds or fails."
+  is_enabled    = var.collect_realtime_metrics
+  tags          = var.tags
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.states"
+  ],
+  "detail-type": [
+    "Step Functions Execution Status Change"
+  ],
+  "detail": {
+    "status": ["FAILED", "SUCCEEDED", "TIMED_OUT", "ABORTED"],
+    "stateMachineArn": [
+      {
+        "prefix": ""
+      }
+    ]
+  }
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "realtime" {
+  arn  = aws_lambda_function.realtime.arn
+  rule = aws_cloudwatch_event_rule.sfn_end.name
+}
+
+resource "aws_lambda_permission" "allow_eventbridge" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.realtime.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.sfn_end.arn
+}
+
+
+####################################################
+#
+# CloudWatch Log groups
+#
+####################################################
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${aws_lambda_function.this.function_name}"
+  retention_in_days = var.lambda_log_retention_in_days
+  tags              = var.tags
+}
+
+resource "aws_cloudwatch_log_group" "realtime" {
+  name              = "/aws/lambda/${aws_lambda_function.realtime.function_name}"
+  retention_in_days = var.lambda_log_retention_in_days
+  tags              = var.tags
+}
+
 
 resource "aws_cloudwatch_dashboard" "this" {
   for_each       = var.create_cloudwatch_dashboard ? toset(local.state_machine_names) : toset([])

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "namespace_for_historical_metrics" {
+  value = local.metric_namespace
+}
+
+output "namespace_for_realtime_metrics" {
+  value = local.metric_namespace_realtime
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2020 Erlend Ekern <dev@ekern.me>
+# Copyright (C) 2021 Vy
 #
 # Distributed under terms of the MIT license.
 

--- a/src/main.py
+++ b/src/main.py
@@ -611,6 +611,37 @@ def filter_processed_executions(executions, s3_bucket, s3_prefix):
     return unprocessed_executions
 
 
+def put_cloudwatch_metrics(metric_datums, metric_namespace):
+    """Publish a list of custom metrics to CloudWatch"""
+    # Batch the requests due to API limits (max. 20 metrics per API call)
+    batch_size = 20
+    cloudwatch = boto3.client("cloudwatch")
+    for i in range(0, len(metric_datums), batch_size):
+        batch_number = (i // batch_size) + 1
+        retries = 0
+        batch = metric_datums[i : i + batch_size]
+        while True:
+            try:
+                response = cloudwatch.put_metric_data(
+                    Namespace=metric_namespace, MetricData=batch
+                )
+                break
+            except botocore.exceptions.ClientError:
+                logger.exception(
+                    "Failed to publish batch #%s of metrics to CloudWatch",
+                    batch_number,
+                )
+                if retries < 2:
+                    retries += 1
+                    continue
+                raise
+
+        logger.debug(
+            "Successfully published batch #%s of metrics to CloudWatch",
+            batch_number,
+        )
+
+
 def lambda_handler(event, context):
     logger.info("Lambda triggered with event '%s'", event)
 
@@ -626,14 +657,27 @@ def lambda_handler(event, context):
 
     dynamodb = boto3.resource("dynamodb")
     dynamodb_table = dynamodb.Table(dynamodb_table_name)
+    if len(state_machine_arns) == 0:
+        logger.info(
+            "No state machine ARNs to collect metrics for were passed in"
+        )
+        state_machines = sfn.list_state_machines()["stateMachines"]
+        state_machine_arns = list(
+            map(lambda s: s["stateMachineArn"], state_machines)
+        )
+        logger.info("Found %s ARNs using the SDK", len(state_machine_arns))
 
     # TODO: Split this logic into smaller, decoupled and testable units
     for state_machine_arn in state_machine_arns:
         state_machine_name = state_machine_arn.split(":")[6]
         s3_prefix = f"{current_account_id}/{state_machine_name}"
-        executions = sfn.list_executions(
-            stateMachineArn=state_machine_arn, maxResults=500,
-        )["executions"]
+        try:
+            executions = sfn.list_executions(
+                stateMachineArn=state_machine_arn, maxResults=500,
+            )["executions"]
+        except sfn.exceptions.StateMachineDoesNotExist:
+            logger.warn("State machine '%s' does not exist", state_machine_arn)
+            continue
         executions = sorted(executions, key=lambda e: e["startDate"])
         completed_executions = []
         first_running_execution = None

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -94,5 +94,7 @@ def lambda_handler(event, context):
                     "StorageResolution": 1,
                 },
             )
-    logger.info("Publish %s custom metrics to CloudWatch", len(metric_datums))
+    logger.info(
+        "Publishing %s custom metrics to CloudWatch", len(metric_datums)
+    )
     put_cloudwatch_metrics(metric_datums, metric_namespace)

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2021 Vy
+#
+# Distributed under terms of the MIT license.
+
+"""
+A Lambda triggered by EventBridge events emitted by
+AWS Step Functions execution updates.
+"""
+
+import json
+import logging
+import os
+import boto3
+
+from main import (
+    get_state_events,
+    get_names_of_entered_states,
+    put_cloudwatch_metrics,
+)
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    logger.info(
+        "Lambda triggered with event: %s", json.dumps(event),
+    )
+    metric_namespace = os.environ["METRIC_NAMESPACE"]
+
+    state_machine_arn = event["detail"]["stateMachineArn"]
+    state_machine_name = state_machine_arn.split(":")[6]
+
+    execution_arn = event["detail"]["executionArn"]
+
+    sfn = boto3.client("stepfunctions")
+    response = sfn.get_execution_history(
+        executionArn=execution_arn, maxResults=500, reverseOrder=True
+    )
+    events = response["events"]
+    state_names = get_names_of_entered_states(events)
+    logger.info(
+        "%s states were entered during the execution", len(state_names)
+    )
+    metric_datums = []
+    for state_name in state_names:
+        state_events = get_state_events(state_name, events)
+        if state_events["success_event"]:
+            metric_datums.append(
+                {
+                    "MetricName": "StateSuccess",
+                    "Timestamp": state_events["success_event"]["timestamp"],
+                    "Dimensions": [
+                        {
+                            "Name": "StateMachineName",
+                            "Value": state_machine_name,
+                        },
+                        {"Name": "StateName", "Value": state_name},
+                    ],
+                    "Value": int(
+                        (
+                            state_events["success_event"]["timestamp"]
+                            - state_events["enter_event"]["timestamp"]
+                        ).total_seconds()
+                        * 1000
+                    ),
+                    "Unit": "Milliseconds",
+                    "StorageResolution": 1,
+                }
+            )
+        elif state_events["fail_event"]:
+            metric_datums.append(
+                {
+                    "MetricName": "StateFail",
+                    "Timestamp": state_events["fail_event"]["timestamp"],
+                    "Dimensions": [
+                        {
+                            "Name": "StateMachineName",
+                            "Value": state_machine_name,
+                        },
+                        {"Name": "StateName", "Value": state_name},
+                    ],
+                    "Value": int(
+                        (
+                            state_events["fail_event"]["timestamp"]
+                            - state_events["enter_event"]["timestamp"]
+                        ).total_seconds()
+                        * 1000
+                    ),
+                    "Unit": "Milliseconds",
+                    "StorageResolution": 1,
+                },
+            )
+    logger.info("Publish %s custom metrics to CloudWatch", len(metric_datums))
+    put_cloudwatch_metrics(metric_datums, metric_namespace)

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,8 @@ variable "name_prefix" {
 }
 
 variable "state_machine_arns" {
-  description = "ARNs of state machines to report metrics on."
+  description = "An optional list of ARNs of state machines to report metrics on. If empty, metrics will be collected for all state machines in the current AWS region."
+  default     = []
   type        = list(string)
 }
 
@@ -20,6 +21,11 @@ variable "states_to_display" {
   type        = list(string)
 }
 
+variable "collect_realtime_metrics" {
+  description = "Whether to collect realtime metrics or not."
+  default     = true
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = map(string)
@@ -31,9 +37,12 @@ variable "lambda_timeout" {
   default     = 300
 }
 
+variable "lambda_log_retention_in_days" {
+  description = "The number of days to retain CloudWatch logs from the Lambda."
+  default     = 14
+}
+
 variable "schedule_expression" {
   description = "The schedule expression (in UTC) to use for the CloudWatch Event Rule that triggers the Lambda."
   default     = "rate(1 hour)"
 }
-
-


### PR DESCRIPTION
- Add a second Lambda function that computes near-realtime metrics
- Create all associated CloudWatch log groups in Terraform instead of out-of-band

## Breaking changes
Updating an existing version of the module with this new version will likely result in an error when running terraform apply due to Terraform trying to create the log group for the Lambda, but it already existing (e.g., Error: Creating CloudWatch Log Group failed: ResourceAlreadyExistsException: The specified log group already exists: The CloudWatch Log Group '/aws/lambda/example-pipeline-metrics' already exists.)